### PR TITLE
Add agent guidelines and playful manual index

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,15 @@
+# Agent Guidelines
+
+## Scope
+These instructions apply to the entire repository unless a more specific `AGENTS.md` overrides them.
+
+## Writing Docs
+- Keep prose short, friendly, and packed with helpful visuals (emojis count!).
+- Favor headings, bullet lists, and callouts over dense paragraphs.
+- Avoid jargon unless you explain it right away.
+- When adding new documents, include a quick "How to use this" section for humans in a hurry.
+
+## Code & Structure
+- Prefer lowercase filenames with hyphens unless the user explicitly requests something else.
+- Never remove existing helpful comments or docs without good reason.
+- If you create directories, add a short README or index so explorers know what's inside.

--- a/The Manual/index.md
+++ b/The Manual/index.md
@@ -1,0 +1,34 @@
+# 🐒 The Manual: Jungle Quick-Start
+
+> **Mission:** Help curious monkeys (that's us!) use DeepCritical without banana slips.
+
+## 🍌 1. Gear Check (What You Need)
+- 🧠 Brain switched to "Play" mode
+- 💻 Terminal or editor ready
+- 📦 Run `pip install -e .` if you want local DeepCritical magic
+
+## 🗺️ 2. Map of the Jungle
+| Path | Treasure | Peek |
+| --- | --- | --- |
+| `README.md` | Big picture of DeepCritical | Start here for storytime |
+| `configs/` | Ready-to-use settings | Try them, tweak them |
+| `tests/` | Safety nets | Run `pytest` to make sure nothing breaks |
+
+## 🛠️ 3. Monkey Tricks
+1. Clone the repo 🍇 `git clone ...`
+2. Jump in 🍍 `cd DeepCritical`
+3. Spin up env 🥥 `uv sync` or `pip install -e .`
+4. Test swing 🦧 `pytest`
+
+## 🚨 4. Banana Peels to Dodge
+- ❌ Skipping tests before pushing
+- ❌ Editing files in `.venv/`
+- ❌ Forgetting to cite sources in docs
+
+## 🎯 5. How to Use This (TL;DR)
+- Need setup? Read sections 1 + 3.
+- Need project map? Section 2 table.
+- Quick safety tips? Section 4.
+- Read it once, keep it handy, share bananas.
+
+![Monkey high five](https://em-content.zobj.net/source/apple/354/high-voltage_26a1.png)


### PR DESCRIPTION
## Summary
- add a repository-wide `AGENTS.md` with concise documentation guidance
- create "The Manual" index with emoji-filled quick-start tips for DeepCritical explorers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e447ceac208325a2c62db1741cf567